### PR TITLE
Use six.texttype for Python 2/3 compatibility

### DIFF
--- a/src/argcache.py
+++ b/src/argcache.py
@@ -34,6 +34,7 @@ from .marinade import marinade_dish
 from .registry import register_cache
 from .sad_face import warn_if_loaded
 from .signals import cache_deleted
+import six
 
 __all__ = ['ArgCache']
 
@@ -445,7 +446,7 @@ class ArgCache(object):
             return
         if filter is None:
             filter = lambda instance: True
-        if isinstance(selector, str):
+        if isinstance(selector, str) or isinstance(selector, six.text_type):
             # Special-case this
             selector_str = selector
             selector = lambda instance: {selector_str: instance}
@@ -488,7 +489,7 @@ class ArgCache(object):
         # HACK: allow cached methods of models to be specified as strings
         # "app.Model.method"
         method_name = None
-        if isinstance(cache_obj, basestring):
+        if isinstance(cache_obj, six.text_type):
             cache_obj, method_name = cache_obj.rsplit(".", 1)
         def resolve_depend_on_cache(cache_obj):
             if method_name is not None:

--- a/src/argcache.py
+++ b/src/argcache.py
@@ -489,7 +489,7 @@ class ArgCache(object):
         # HACK: allow cached methods of models to be specified as strings
         # "app.Model.method"
         method_name = None
-        if isinstance(cache_obj, six.text_type):
+        if isinstance(cache_obj, six.text_type) or isinstance(cache_obj, basestring):
             cache_obj, method_name = cache_obj.rsplit(".", 1)
         def resolve_depend_on_cache(cache_obj):
             if method_name is not None:

--- a/src/argcache.py
+++ b/src/argcache.py
@@ -489,7 +489,7 @@ class ArgCache(object):
         # HACK: allow cached methods of models to be specified as strings
         # "app.Model.method"
         method_name = None
-        if isinstance(cache_obj, six.text_type) or isinstance(cache_obj, basestring):
+        if isinstance(cache_obj, basestring):
             cache_obj, method_name = cache_obj.rsplit(".", 1)
         def resolve_depend_on_cache(cache_obj):
             if method_name is not None:

--- a/src/queued.py
+++ b/src/queued.py
@@ -26,13 +26,12 @@ import types
 
 from django.apps import apps
 from django.db.models import signals
-import six
 
 pending_lookups = {}
 
 def add_lazy_dependency(self, obj, operation):
     """ If obj is a function (thunk), delay operation; otherwise execute immediately. """
-    if isinstance(obj, six.text_type) or isinstance(obj, basestring):
+    if isinstance(obj, basestring):
         app_label, model_name = obj.split(".")
         try:
             # This is a private API, please fix it!

--- a/src/queued.py
+++ b/src/queued.py
@@ -32,7 +32,7 @@ pending_lookups = {}
 
 def add_lazy_dependency(self, obj, operation):
     """ If obj is a function (thunk), delay operation; otherwise execute immediately. """
-    if isinstance(obj, six.text_type):
+    if isinstance(obj, six.text_type) or isinstance(obj, basestring):
         app_label, model_name = obj.split(".")
         try:
             # This is a private API, please fix it!

--- a/src/queued.py
+++ b/src/queued.py
@@ -26,12 +26,13 @@ import types
 
 from django.apps import apps
 from django.db.models import signals
+import six
 
 pending_lookups = {}
 
 def add_lazy_dependency(self, obj, operation):
     """ If obj is a function (thunk), delay operation; otherwise execute immediately. """
-    if isinstance(obj, basestring):
+    if isinstance(obj, six.text_type):
         app_label, model_name = obj.split(".")
         try:
             # This is a private API, please fix it!


### PR DESCRIPTION
Use six.texttype for cases of `isinstance` for Python 2/3 compatibility. 

This was tested on the `python3` branch of ESP-Website. I locally changed requirements.txt (for Python 2) for argcache to point to this new branch, and (after incorporating some additional changes in https://github.com/learning-unlimited/ESP-Website/pull/3416), the Python 2 tests succeed for ESP-Website. 

When porting to these changes to the `python3` branch of django-argcache, all occurrences of `basestring` will need to be changed to `six.text_type`, I guess. For some reason, if I make this change under Python 2, things break. 